### PR TITLE
skip alias packages when checking patches

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -14,6 +14,7 @@ use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
+use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Installer\PackageEvents;
@@ -93,7 +94,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       }
 
       foreach ($packages as $package) {
-        if (array_key_exists($package->getName(), $tmp_patches) && !empty($tmp_patches[$package->getName()])) {
+        if (!($package instanceof AliasPackage) && array_key_exists($package->getName(), $tmp_patches) && !empty($tmp_patches[$package->getName()])) {
           $uninstallOperation = new UninstallOperation($package, 'Removing package so it can be re-installed and re-patched.');
           $this->io->write('<info>Removing package ' . $package->getName() . ' so that it can be re-installed and re-patched.</info>');
           $installationManager->uninstall($localRepository, $uninstallOperation);


### PR DESCRIPTION
drupal/[my_module] packages fetched from https://packagist.drupal-composer.org have branch aliases for the N.x-M.x-dev releases :

(snippet from my composer.json)

``` json
    "require": {
        "composer/installers": "^1.0.20",
        "cweagans/composer-patches": "^1.2@dev",
        "drupal/core": "8.0.*",
        "drupal/devel": "8.1.*@dev",
    },
    ...
    "extra": {
        "patches": {
            "drupal/devel": {
                "https://www.drupal.org/node/2428795": "https://www.drupal.org/files/issues/devel-pluggable-dumper-2191395-11.patch"
            }
        }
    }
```

(snippet from my composer.lock)

``` json
{
            "name": "drupal/devel",
            "version": "dev-8.x-1.x",
            ...
            "require": {
                "drupal/core": "8.*"
            },
            ...
            "type": "drupal-module",
            "extra": {
                "branch-alias": {
                    "dev-8.x-1.x": "8.1.x-dev"
                }
            },
            ...
        }
```

These branch aliases show up as duplicate packages in $localRepository->getPackages()
i.e drupal/devel appears twice in $localRepository->getPackages(), once as a Composer\Package\AliasPackage, and once as a Composer\Package\CompletePackage

Meaning, if I have patches for drupal/devel, the current code does the "Removing package so it can be re-installed and re-patched" operation twice :

```
> composer install
Gathering patches for root package.
Removing package drupal/devel so that it can be re-installed and re-patched.
Deleting web/modules/contrib/devel - deleted
Removing package drupal/devel so that it can be re-installed and re-patched.
Deleting web/modules/contrib/devel - deleted
```
